### PR TITLE
fix: extract multiple dlt frames per udp packet

### DIFF
--- a/src/dltFileWriter.ts
+++ b/src/dltFileWriter.ts
@@ -44,4 +44,46 @@ export class DltFileWriter {
         fs.writeFileSync(this.fileHandle, rawMsgData);
     }
 
+    /**
+     * write potentially multiple dlt messages with storage header from a raw payload buffer
+     *
+     * A udp dlt message can contain in one udp packet multiple packets. We're parsing the 
+     * payload buffer for the length and then writing multiple messages.
+     * 
+     * @param seconds seconds to use for the SH
+     * @param micros microseconds to use for the SH
+     * @param rawMsgData buffer with data reflecting a dlt message
+     * @returns number of messages parsed/written
+     */
+    public parseAndWriteRaw(seconds: number, micros: number, rawMsgsData: Buffer):number {
+        let nrMsgs = 0;
+        assert(this.fileHandle !== -1, "DltFileWriter.parseAndWriteRaw fileHandle invalid!");
+
+        let lenAvail = rawMsgsData.length;
+        let processed = 0;
+        while (lenAvail>4){
+            // StandardHeader: 1 byte HTYP, 1 byte MCNT, 2 byte (BE) len:
+            // len includes the standardheader
+            const msgLen = rawMsgsData.readUInt16BE(processed+2);
+            if (msgLen >= 4 && msgLen <= lenAvail){
+                // write that msg:
+                this.bufStorageHeader.writeUInt32LE(seconds, 4);
+                this.bufStorageHeader.writeInt32LE(micros, 8);
+                fs.writeFileSync(this.fileHandle, this.bufStorageHeader);
+                fs.writeFileSync(this.fileHandle, rawMsgsData.slice(processed, processed+msgLen));
+                nrMsgs+=1;
+                processed += msgLen;
+                lenAvail -= msgLen;
+            }else{
+                console.warn(`DltFileWriter.parseAndWriteRaw msgLen ${msgLen} invalid at offset ${processed}! (lenAvail=${lenAvail})`);
+                lenAvail = 0;
+            }
+        }
+        if (processed < rawMsgsData.length){
+            console.warn(`DltFileWriter.parseAndWriteRaw ignored data, processed=${processed}/${rawMsgsData.length}!`);
+        }
+
+        return nrMsgs;
+    }
+
 }

--- a/src/filterPcap.ts
+++ b/src/filterPcap.ts
@@ -155,15 +155,15 @@ async function extractDltMethod(uris: readonly vscode.Uri[], confMethod: MethodC
                     const [payLoadInByteModulus, payloadInByteSize] = confMethod?.options?.payloadInByte || [0, 1];
 
                     const processRawPayload = (lines: readonly string[]) => {
-                        //console.log(`onDidChangeData(lines.length=${lines.length}`);
+                        // console.log(`processRawPayload.onDidChangeData(lines.length=${lines.length}) payLoadInByteSize=${payloadInByteSize} payLoadInByteModulus=${payLoadInByteModulus}`);
                         for (let i = 0; i < lines.length; ++i) {
                             const line = lines[i].split('\t');
                             const [strSeconds, strMicros] = line[0].split('.');
                             const seconds = Number(strSeconds);
                             const micros = Number(strMicros.slice(0, 6).padEnd(6, '0'));
                             const bufPayload = Buffer.from(line[1], "hex");
-                            dltFileWriter.writeRaw(seconds, micros, payloadInByteSize > 1 ? Buffer.from(bufPayload.filter((v, i) => i % payloadInByteSize === payLoadInByteModulus)) : bufPayload);
-                            nrMsgs++;
+                            // console.log(` line ${i}: bufPayload.length=${bufPayload.length}`);
+                            nrMsgs += dltFileWriter.parseAndWriteRaw(seconds, micros, payloadInByteSize > 1 ? Buffer.from(bufPayload.filter((v, i) => i % payloadInByteSize === payLoadInByteModulus)) : bufPayload);
                         }
                     };
 


### PR DESCRIPTION
UDP packets can contain multiple DLT logs.
Adding parsing of DLT standard header for the length and write multiple logs with same reception time.