### PR TITLE
fix: add support for wireshark >= v4.1

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -61,6 +61,8 @@
 		var g_ws_allColumns = null;
 
 		var g_ws_pref = {};
+		var g_ws_version = null;
+		var g_ws_version_gte_4_1 = true;
 
 		var g_ws_default_pref =
 		{
@@ -575,8 +577,10 @@
 						g_ws_rtd = data['rtd'];
 						g_ws_convs = data['convs'];
 						g_ws_ftypes = data['ftypes'];
-
-						document.title = document.title.replace("${WEBSHARK_VER}", data['version']);
+						g_ws_version = data['version'];
+						g_ws_version_gte_4_1 = compare_ws_version(g_ws_version, '4.1')>=0;
+						console.log(`g_ws_version='${g_ws_version}'' g_ws_version_gte_4_1=${g_ws_version_gte_4_1}`);
+						document.title = document.title.replace("${WEBSHARK_VER}", g_ws_version);
 						console.log('load document.title=' + document.title);
 						setup_user_toolbar(data['user']);
 						console.log('load data[user]=' + JSON.stringify(data['user']));

--- a/web/js/webshark-app.js
+++ b/web/js/webshark-app.js
@@ -602,7 +602,13 @@
 			var ref_framenum = g_webshark.getRefFrame(framenum);
 			if (ref_framenum)
 				load_req['ref_frame'] = ref_framenum;
-			load_req['prev_frame'] = false; // framenum - 1;   /* TODO */
+				// the parameter 'prev_frame' changes with wireshark 4.1 from bool to uinteger
+				// https://gitlab.com/wireshark/wireshark/-/commit/39aa3cb58af77a91e05972a440d35fbb93d4273d
+				if (!g_ws_version_gte_4_1){
+					load_req['prev_frame'] = false;
+				}else{
+					// optional UINTEGER for now we don't have a prev_frame so we dont get relative info TODO
+				}			
 
 			webshark_json_get(load_req,
 				function (data) {

--- a/web/tools.js
+++ b/web/tools.js
@@ -31,3 +31,28 @@ function sharkdResponse(res) {
         console.log('sharkdResponse err:' + err, JSON.stringify(res));
     }
 }
+
+/// compare a wireshark version string with a reference version string
+/// @param ws_vers: the version string to compare (e.g. "v4.0.10-0-gf...")
+/// @param ref_vers: the reference version string (e.g. "4.1.0")
+/// @return: -1 if ws_vers < ref_vers, 0 if ws_vers == ref_vers, 1 if ws_vers > ref_vers
+///
+/// Note: this function is not complete, it only compares the major, minor and patch version
+/// Note: it assumes the ws_vers string starts with the format "vX.Y.Z"
+/// todo: change to use semver lib (with webpack bundling...)
+function compare_ws_version(ws_vers, ref_vers){
+    if (!ws_vers.startsWith("v")) {
+        console.error("compare_ws_version: invalid ws_vers string", ws_vers, ref_vers);
+        return 0; // return 0 (= equal here...)
+    }
+    const ws_vers_parts = ws_vers.slice(1).split(".");
+    const ref_vers_parts = ref_vers.split(".");
+    for (let i = 0; i < ref_vers_parts.length; i++) {
+        let ws_part = parseInt(ws_vers_parts[i]);
+        if (isNaN(ws_part)) { ws_part = 0; }
+        const ref_part = parseInt(ref_vers_parts[i]);
+        if (ws_part < ref_part) { return -1; }
+        if (ws_part > ref_part) { return 1; }
+    }
+    return 0;
+}


### PR DESCRIPTION
v4.1 introduced a change in the frame command for parameter 'prev_frame' to be uinteger and not boolean.

Added basic version detection and check for >= v4.1. Tested with v4.0.10, v4.2.7 and v4.4.0.
Issue: about settings #29