### PR TITLE
feat: add support for gz/zst/lz4 extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If you install from source (git clone https://github.com/wireshark/wireshark; cd
 ## Features
 
 - Open 'pcap'/'pcapng' network capture files. Use command "Open pcap file..." or with vscode >=1.46 directly open cap/pcap/pcapng files.
+- Compressed pcap/pcapng files are supported as well with extensions cap|pcap|pcapng.gz|zst|lz4
 - Display filter with known syntax from wireshark
 - **Time sync** feature.
   - Calculates time for each frame based on timestamp and broadcasts the time to the other **Time sync** extensions so that they reveal the fitting time ranges.

--- a/package.json
+++ b/package.json
@@ -53,13 +53,13 @@
         "displayName": "pcap/pcapng/cap",
         "selector": [
           {
-            "filenamePattern": "*.pcap"
+            "filenamePattern": "{*.pcap,*.pcap.gz,*.pcap.zst,*.pcap.lz4}"
           },
           {
-            "filenamePattern": "*.pcapng"
+            "filenamePattern": "{*.pcapng,*.pcapng.gz,*.pcapng.zst,*.pcapng.lz4}"
           },
           {
-            "filenamePattern": "*.cap"
+            "filenamePattern": "{*.cap,*.cap.gz,*.cap.zst,*.cap.lz4}"
           }
         ]
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,7 +102,9 @@ export function activate(context: vscode.ExtensionContext) {
             canSelectFiles: true,
             canSelectFolders: false,
             canSelectMany: false,
-            filters: { 'pcap files': ['pcap', 'cap', 'pcapng'] },
+            filters: {
+              'pcap files': ['pcap', 'cap', 'pcapng'].flatMap((ext) => [ext, ext + '.gz', ext + '.zst', ext + '.lz4']),
+            },
             openLabel: 'Select pcap file to open...',
           })
           .then(async (uris: vscode.Uri[] | undefined) => {
@@ -145,7 +147,7 @@ export function activate(context: vscode.ExtensionContext) {
           canSelectFiles: true,
           canSelectFolders: false,
           canSelectMany: true,
-          filters: { 'pcap files': ['pcap', 'cap', 'pcapng'] },
+          filters: { 'pcap files': ['pcap', 'cap', 'pcapng'].flatMap((ext) => [ext, ext + '.gz', ext + '.zst', ext + '.lz4']) },
           openLabel: 'Select pcap file to filter...',
         })
         .then(async (uris: vscode.Uri[] | undefined) => {
@@ -167,7 +169,7 @@ export function activate(context: vscode.ExtensionContext) {
           canSelectFiles: true,
           canSelectFolders: false,
           canSelectMany: true,
-          filters: { 'pcap files': ['pcap', 'cap', 'pcapng'] },
+          filters: { 'pcap files': ['pcap', 'cap', 'pcapng'].flatMap((ext) => [ext, ext + '.gz', ext + '.zst', ext + '.lz4']) },
           openLabel: 'Select pcap file to extract DLT from...',
         })
         .then(async (uris: vscode.Uri[] | undefined) => {
@@ -189,7 +191,7 @@ export function activate(context: vscode.ExtensionContext) {
           canSelectFiles: true,
           canSelectFolders: false,
           canSelectMany: true,
-          filters: { 'pcap files': ['pcap', 'cap', 'pcapng'] },
+          filters: { 'pcap files': ['pcap', 'cap', 'pcapng'].flatMap((ext) => [ext, ext + '.gz', ext + '.zst', ext + '.lz4']) },
           openLabel: 'Select pcap file to remove TECMP headers from...',
         })
         .then(async (uris: vscode.Uri[] | undefined) => {


### PR DESCRIPTION
Pcap/pcapng/cap files with extension .pcapng.gz ... are supported as well. Tested with wireshark/sharkd 4.4.0.

Issue: Can not open pcap.gz #42