### PR TITLE
feat: apply properties by setconf before load files

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ This extension contributes the following settings:
   * `name`: a name to identify
   * `steps`: similar to filterSteps but for the "extract DLT from pcap file..." function.
   * `tSharkArgs`: arguments used for tshark to extract the DLT message payload from the pcap file.
-
+* `vsc-webshark.sharkdConfigurations`: An array of configurations for sharkd. For more details, refer to [setconf](https://wiki.wireshark.org/sharkd-JSON-RPC-Request-Syntax#setconf).
+  Each configuration item includes:
+  * `name`: The name of the property.
+  * `value`: The corresponding value for the configuration.
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -591,6 +591,24 @@
             },
             "default": [],
             "description": "Steps offered for the 'Remove TECMP from pcap file...' function"
+          },
+          "vsc-webshark.sharkdConfigurations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "sharkd configurations",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "config name, check https://wiki.wireshark.org/sharkd-JSON-RPC-Request-Syntax#setconf for more infomation"
+                },
+                "value": {
+                  "description": "config value"
+                }
+              }
+            },
+            "default": [],
+            "description": "Load sharkd config by setconf when open webshharkview."
           }
         }
       }

--- a/src/websharkView.ts
+++ b/src/websharkView.ts
@@ -540,6 +540,20 @@ export class WebsharkView implements vscode.Disposable {
                 }
             }
         };
+
+        // load config for sharkd
+
+        const sharkdConf = <any[]>(vscode.workspace.getConfiguration().get("vsc-webshark.sharkdConfigurations"));
+        for (const conf of sharkdConf) {
+          this.sharkd2Request({ req: 'setconf', params: { name: conf.name, value: conf.value } }, (res: any) => {
+            console.log(`WebsharkView sharkd2 'setconf ${conf.name}=${conf.value}' got res=${JSON.stringify(res)}`);
+            if ('error' in res) {
+                console.error(`WebsharkView sharkd2 'setconf' got error=${res.error}`);
+                // if not err: 0 we could e.g. kill and don't offer time services...
+            }
+          });
+        }
+
         // load the file here as well: todo might delay until the first one has fully loaded the file
         // but with all our multi-core cpus it should run fine in parallel... todo
         // as long as sharkd2 is not ready it's not granted that requests are done in fifo order.


### PR DESCRIPTION
Load sharkd config by [setconf](https://wiki.wireshark.org/sharkd-JSON-RPC-Request-Syntax#setconf) from `vsc-webshark.sharkdConfigurations` when open webshharkview. This feature can be used to set the protocol.
For example, you can enable usbip protocol by:
``` json
"vsc-webshark.sharkdConfigurations": [
        {
            "name": "usbip.tcp.port",
            "value": 3240
        }
    ],
```

![image](https://github.com/user-attachments/assets/da5db3d2-4270-4923-8261-93603e1c7d01)
