### PR TITLE
fix: svgs/icons use theme based color

### DIFF
--- a/web/css/webshark.css
+++ b/web/css/webshark.css
@@ -109,6 +109,9 @@ table.ws_border
 .ws_cell_expert_color_Warning { background-color: #f7f253; }
 .ws_cell_expert_color_Error   { background-color: #ff5c5c; }
 
+.ws_glyph_img {
+	color: var(--vscode-editor-foreground);
+}
 ul.menul
 {
 	list-style-type: none;

--- a/web/js/webshark-app.js
+++ b/web/js/webshark-app.js
@@ -3904,23 +3904,24 @@
 
 						svg.append("svg:path")
 							.attr("d", fa_paths[what])
-							.style("fill", "#191970");
+							.style("fill", "currentColor");
 						break;
 					}
 			}
 
-			var str = 'data:image/svg+xml;base64,' + window.btoa(svg.node().outerHTML);
-			m_glyph_cache[what] = str;
-			return str;
+			m_glyph_cache[what] = svg;
+      return svg;
 		}
 
 		function webshark_glyph_img(what, width) {
-			var img = document.createElement('img');
-
-			img.setAttribute('src', webshark_glyph(what));
-			img.setAttribute('width', width);
-			return img;
-		}
+			var img = webshark_glyph(what).node().cloneNode(true);
+      img.classList.add('ws_glyph_img');
+			img.setAttribute('role', 'img');
+			img.setAttribute('aria-labelledby',what);
+      img.setAttribute('width', width);
+			img.setAttribute('height', width);
+      return img;
+    }
 
 		exports.webshark_glyph_img = webshark_glyph_img;
 


### PR DESCRIPTION
Changed the <img... svg=...> to <svg> with class to use editor-foreground color.

Noticed that the buttons/icons are non functional (see #55).

Fixes: Button contrast in dark mode #49